### PR TITLE
Work on stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,2 @@
 language: rust
-rust: nightly
+rust: stable

--- a/src/ecs/mod.rs
+++ b/src/ecs/mod.rs
@@ -39,7 +39,6 @@
 use std::any::{Any, TypeId};
 use std::collections::HashMap;
 use std::mem;
-use std::raw::TraitObject;
 
 pub use self::vec_mapper::VecMapper;
 pub use self::world::{World, WorldBuilder};
@@ -97,9 +96,10 @@ where T: Component, M: ComponentMapper<Component=T> + 'static {
 }
 
 /// used to maintain ownership of the mapper so it destructs properly,
-/// while storing a `TraitObject` for runtime polymorphism.
+/// while storing a pair of pointers to 
+///the trait object's data and vtable for runtime polymorphism.
 struct MapperHandle {
-    obj: TraitObject,
+    obj: (*mut (), *mut ()),
     handle: Box<ComponentMapperExt>,
 }
 
@@ -108,7 +108,7 @@ impl MapperHandle {
     fn from_mapper<T, M>(mapper: M) -> MapperHandle
     where T: Component, M: ComponentMapper<Component=T> + 'static {
         let mut mapper = Box::new(mapper);
-        let obj: TraitObject = unsafe {
+        let obj: (*mut (), *mut ()) = unsafe {
             mem::transmute(&mut *mapper as &mut ComponentMapper<Component=T>)
         };
         MapperHandle {

--- a/src/ecs/world.rs
+++ b/src/ecs/world.rs
@@ -40,7 +40,7 @@ impl World {
             for entity in entity_vecs.into_iter().flat_map(|v|
                 v.into_iter()
             ) {
-                let counter = counts.entry(*entity).or_insert(0);
+                let counter = counts.entry(entity).or_insert(0);
                 *counter += 1;
             }
             

--- a/src/ecs/world.rs
+++ b/src/ecs/world.rs
@@ -27,18 +27,26 @@ impl World {
     pub fn process_systems(&mut self) {
         for sys in &mut self.systems {
             let comps = sys.dependent_components();
-            let num_components = comps.len();
-            if num_components == 0 { continue; }
-            // Find entities which contain requisite component types.
-            let mut entities = Vec::new();
-            for id in &comps {
-                entities.append(
-                    &mut self.component_mappers.get_handle(id).unwrap().entities()
-                );
+            let mut counts: HashMap<Entity, usize> = HashMap::new();
+            for entity_vecs in comps.iter().map(|c|
+                self.component_mappers
+                .get_handle(c)
+                .unwrap()
+                .entities()
+            ) {
+                for e in entity_vecs.iter() {
+                    let counter = counts.entry(e).or_insert(0);
+                    *counter += 1;
+                }
             }
-            if num_components > 1 {
-                entities = duplicate_n_times(entities, num_components);
-            }
+            
+            let entities = counts.iter().filter_map(|(e, c)|
+                if *c == comps.len() { Some(*e) }
+                else { None }
+            ).collect::<Vec<_>>();
+            
+            if entities.len() == 0 { continue }
+            
             sys.process(&entities, &mut self.component_mappers);
         }
     }
@@ -104,38 +112,6 @@ impl DerefMut for World {
     fn deref_mut(&mut self) -> &mut ComponentMappers {
         &mut self.component_mappers
     }
-}
-
-// Helper function for system processing.
-// Returns a vector of all values in v which are duplicate at least n times.
-#[inline]
-fn duplicate_n_times<T: Ord + Eq + Clone>(v: Vec<T>, n: usize) -> Vec<T> {
-    if v.len() == 0 { return v }
-    else if n == 0 { return Vec::new() }
-
-    let mut v = v;
-    let mut duplicates = Vec::new();
-
-    v.sort_by(|a, b| a.cmp(b));
-
-    let mut i = 1;
-    let mut prev_val = &v[0];
-    let mut count = 1;
-    while i < v.len() {
-        let cur_val = &v[i];
-        if *prev_val == *cur_val {
-            count += 1;
-        } else {
-            prev_val = cur_val;
-            count = 1;
-        }
-
-        if count == n { duplicates.push(cur_val.clone()) } 
-
-        i += 1;
-    }
-
-    duplicates
 }
 
 /// Factory for `World`. 

--- a/src/ecs/world.rs
+++ b/src/ecs/world.rs
@@ -29,7 +29,7 @@ impl World {
             let comps = sys.dependent_components();
             let mut counts: HashMap<Entity, usize> = HashMap::new();
             for entity in comps.iter().flat_map(|c|
-                self.component_mappers
+                (&mut self.component_mappers)
                 .get_handle(c)
                 .unwrap()
                 .entities()

--- a/src/ecs/world.rs
+++ b/src/ecs/world.rs
@@ -27,8 +27,9 @@ impl World {
     pub fn process_systems(&mut self) {
         for sys in &mut self.systems {
             let mut counts: HashMap<Entity, usize> = HashMap::new();
+            let comps = sys.dependent_components();
             let mut entity_vecs = Vec::new();
-            for c in sys.dependent_components() {
+            for c in &comps {
                 entity_vecs.push(
                     &self.component_mappers
                     .get_handle(c)

--- a/src/ecs/world.rs
+++ b/src/ecs/world.rs
@@ -31,7 +31,7 @@ impl World {
             let mut entity_vecs = Vec::new();
             for c in &comps {
                 entity_vecs.push(
-                    &self.component_mappers
+                    self.component_mappers
                     .get_handle(c)
                     .unwrap()
                     .entities()

--- a/src/ecs/world.rs
+++ b/src/ecs/world.rs
@@ -26,14 +26,17 @@ impl World {
     /// Process all the systems in this world in arbitrary order.
     pub fn process_systems(&mut self) {
         for sys in &mut self.systems {
-            let comps = sys.dependent_components();
             let mut counts: HashMap<Entity, usize> = HashMap::new();
-            for entity in comps.iter().flat_map(|c|
-                (&mut self.component_mappers)
-                .get_handle(c)
-                .unwrap()
-                .entities()
-                .into_iter()
+            let mut entity_vecs = Vec::new();
+            for c in sys.dependent_components() {
+                entity_vecs.push(
+                    &self.component_mappers
+                    .get_handle(c)
+                    .unwrap()
+                    .entities())
+            }
+            for entity in entity_vecs.into_iter().flat_map(|v|
+                v.into_iter()
             ) {
                 let counter = counts.entry(entity).or_insert(0);
                 *counter += 1;

--- a/src/ecs/world.rs
+++ b/src/ecs/world.rs
@@ -28,16 +28,15 @@ impl World {
         for sys in &mut self.systems {
             let comps = sys.dependent_components();
             let mut counts: HashMap<Entity, usize> = HashMap::new();
-            for entity_vecs in comps.iter().map(|c|
+            for entity in comps.iter().flat_map(|c|
                 self.component_mappers
                 .get_handle(c)
                 .unwrap()
                 .entities()
+                .into_iter()
             ) {
-                for e in entity_vecs.iter() {
-                    let counter = counts.entry(e).or_insert(0);
-                    *counter += 1;
-                }
+                let counter = counts.entry(entity).or_insert(0);
+                *counter += 1;
             }
             
             let entities = counts.iter().filter_map(|(e, c)|

--- a/src/ecs/world.rs
+++ b/src/ecs/world.rs
@@ -34,12 +34,13 @@ impl World {
                     &self.component_mappers
                     .get_handle(c)
                     .unwrap()
-                    .entities())
+                    .entities()
+                );
             }
             for entity in entity_vecs.into_iter().flat_map(|v|
                 v.into_iter()
             ) {
-                let counter = counts.entry(entity).or_insert(0);
+                let counter = counts.entry(*entity).or_insert(0);
                 *counter += 1;
             }
             

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,1 @@
-#![feature(append)]
-
 pub mod ecs;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,3 @@
-#![feature(raw, append)]
+#![feature(append)]
 
 pub mod ecs;


### PR DESCRIPTION
Removed dependence on nightly features. The way I got rid of TraitObject is a little hacky but works perfectly. Append has been removed in favor of flat_map, and the new HashMap-based solution in process_systems() for finding eligible entities has a much better algorithmic complexity then the horrible duplicate_n_times approach and should perform much better for large amounts of entities. Sorry about all the failing commits, but I'm developing from my phone and using Travis to check whether the code compiles. Fixes #6.